### PR TITLE
[Fix] Deprecation warning on macOS 12+

### DIFF
--- a/Sources/Progress-Bar/LinearProgress.swift
+++ b/Sources/Progress-Bar/LinearProgress.swift
@@ -31,7 +31,7 @@ public struct LinearProgress: View {
                 foregroundColor
                     .mask(Rectangle()
                             .cornerRadius(geometry.size.width/7)
-                            .animation(.linear))
+                            .animation(.linear, value: percentage))
                     .frame(width: min(geometry.size.width*percentage, geometry.size.width) , height: geometry.size.height)
             }
         }


### PR DESCRIPTION
Hi, this fixes the deprecation warning on macOS 12+ in LinearProgress.swift